### PR TITLE
Scope the Stack Item margin-left reset to immediate children of vertical Stack

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,8 @@
 
 - `Stack` applies spacing correctly when in vertical mode
   ([#142](https://github.com/envoy/polarwind/pull/142))
+- Remove negative margin when nesting a horizontal Stack inside a vertical Stack
+  ([#147](https://github.com/envoy/polarwind/pull/147))
 
 ### Documentation
 

--- a/src/components/Stack/Stack.module.css
+++ b/src/components/Stack/Stack.module.css
@@ -49,7 +49,7 @@
 .vertical {
   @apply flex-col ml-0;
 
-  .Item {
+  & > .Item {
     @apply ml-0;
   }
 }

--- a/src/components/Stack/Stack.stories.mdx
+++ b/src/components/Stack/Stack.stories.mdx
@@ -31,3 +31,20 @@ import { Badge } from "../Badge";
 
 Use to quickly lay out a horizontal row of components and maintain their relative sizes.
 On small screens, children rows wrap down to additional rows as needed.
+
+### Vertical Stack
+
+Use to lay out a vertical row of components.
+
+<Preview>
+  <Story name="Vertical">
+    <Stack vertical>
+      <Badge>Basic</Badge>
+      <Badge>Premium</Badge>
+      <Stack>
+        <Badge>Enterprise</Badge>
+        <Badge>Enterprise Plus</Badge>
+      </Stack>
+    </Stack>
+  </Story>
+</Preview>


### PR DESCRIPTION
Fixes #146 

After fix,

![image](https://user-images.githubusercontent.com/269/87580297-25caf300-c68c-11ea-9954-7652b09b077e.png)
