### PR TITLE
Button fixes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,11 @@
 
 ### Bug fixes
 
+- Plain and outline buttons now have a white background
+  ([#150](https://github.com/envoy/polarwind/pull/150))
+- Button and Link accept a download prop
+  ([#150](https://github.com/envoy/polarwind/pull/150))
+
 ### Documentation
 
 ### Development workflow

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
     "\\.css$": "identity-obj-proxy",
   },
   testPathIgnorePatterns: ["/node_modules/", "/examples/"],
+  clearMocks: true,
 };

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -13,6 +13,7 @@ export const Button = ({
   children,
   className,
   disabled,
+  download,
   icon,
   onClick,
   outline,
@@ -56,7 +57,12 @@ export const Button = ({
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <a className={className}>{content}</a>
     ) : (
-      <UnstyledLink className={className} url={url} onClick={onClick}>
+      <UnstyledLink
+        className={className}
+        download={download}
+        url={url}
+        onClick={onClick}
+      >
         {content}
       </UnstyledLink>
     )
@@ -79,6 +85,8 @@ Button.propTypes = {
   className: PropTypes.string,
   /** Disables the button, disallowing interaction */
   disabled: PropTypes.bool,
+  /** Instructs the browser to download the file */
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /** Icon to display to the left of the button content */
   icon: PropTypes.func,
   /** Callback when clicked */

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -53,7 +53,7 @@
 }
 
 .plain {
-  @apply bg-transparent border-transparent text-carbon-80%;
+  @apply bg-white border-transparent text-carbon-80%;
 
   &:hover {
     @apply bg-arctic;
@@ -78,7 +78,7 @@
 }
 
 .brandOutline {
-  @apply text-brand bg-transparent;
+  @apply text-brand bg-white;
 
   &:hover {
     @apply bg-brand-lightest;

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -139,3 +139,25 @@ navigational link)
     </Stack>
   </Story>
 </Preview>
+
+### Download
+
+`Button` accepts a `download` prop for buttons that use the `url` prop to hint to browsers
+that it should download the file instead of navigating to it.
+
+<Preview>
+  <Story name="Download">
+    <Stack distribution="equalSpacingAround">
+      <Button url="https://www.google.com" download>
+        Download Google homepage
+      </Button>
+      <Button url="https://www.google.com" download="google.html">
+        Customize the filename
+      </Button>
+      <Button url="https://www.google.com" download={false}>
+        Download set to false
+      </Button>
+      <Button download>No effect on non-URL button</Button>
+    </Stack>
+  </Story>
+</Preview>

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -47,14 +47,16 @@ style can be used for tertiary actions.
 
 <Preview>
   <Story name="Styles">
-    <Stack distribution="equalSpacingAround">
-      <ButtonGroup>
-        <Button>Invite</Button>
-        <Button brandOutline>Invite</Button>
-        <Button outline>Invite and add another</Button>
-      </ButtonGroup>
-      <Button plain>Cancel</Button>
-    </Stack>
+    <div style={{ backgroundColor: "#f6f6f9", padding: "1rem" }}>
+      <Stack distribution="equalSpacingAround">
+        <ButtonGroup>
+          <Button>Invite</Button>
+          <Button brandOutline>Invite</Button>
+          <Button outline>Invite and add another</Button>
+        </ButtonGroup>
+        <Button plain>Cancel</Button>
+      </Stack>
+    </div>
   </Story>
 </Preview>
 

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -13,6 +13,7 @@ const cx = classnames.bind(styles);
  */
 export const Link = ({
   children,
+  download,
   external,
   monochrome,
   onClick,
@@ -32,6 +33,7 @@ export const Link = ({
   return (
     <Linkable
       className={className}
+      download={download}
       external={external}
       url={url}
       onClick={handleClick}
@@ -44,6 +46,8 @@ export const Link = ({
 Link.propTypes = {
   /** The content to display inside the link */
   children: PropTypes.node,
+  /** Instructs the browser to download the file */
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /** Makes the link open in a new tab */
   external: PropTypes.bool,
   /** Makes the link color the same as the current text color and adds an underline */

--- a/src/components/Link/tests/Link.test.js
+++ b/src/components/Link/tests/Link.test.js
@@ -19,3 +19,12 @@ test("when monochrome is true, underline can be disabled explicitly", () => {
   );
   expect(screen.getByRole("link")).not.toHaveClass(styles.underlined);
 });
+
+test("supports the download prop", () => {
+  render(
+    <Link download url="/">
+      Home
+    </Link>
+  );
+  expect(screen.getByRole("link")).toHaveAttribute("download");
+});

--- a/src/components/UnstyledLink/UnstyledLink.js
+++ b/src/components/UnstyledLink/UnstyledLink.js
@@ -21,7 +21,14 @@ function isOwnUrl(url) {
  * It provides behaviors when dealing with internal and external links, and sending
  * navigation events to the parent if run in an embedded way.
  */
-export const UnstyledLink = ({ children, external, onClick, url, ...rest }) => {
+export const UnstyledLink = ({
+  children,
+  download,
+  external,
+  onClick,
+  url,
+  ...rest
+}) => {
   const origin = useContext(OriginContext);
   const embedded = useContext(EmbeddedContext);
   const { sendMessage } = useParent();
@@ -29,8 +36,10 @@ export const UnstyledLink = ({ children, external, onClick, url, ...rest }) => {
   const isHostUrl = isAbsoluteUrlFor(url, origin);
   const isThirdPartyUrl = !isOwnUrl(url) && !isHostUrl;
   // popup when explicitly set. if it's not set, popup when it's a third party url in
-  // embedded mode
-  const popup = external ?? (embedded && isThirdPartyUrl);
+  // embedded mode. but if download it set, ignore all of that.
+  const shouldPopup = download
+    ? false
+    : external ?? (embedded && isThirdPartyUrl);
   const shouldSendMessage = embedded && isHostUrl;
 
   const handleClick = useCallback(
@@ -47,11 +56,18 @@ export const UnstyledLink = ({ children, external, onClick, url, ...rest }) => {
     [shouldSendMessage, sendMessage, onClick]
   );
 
-  const target = popup ? "_blank" : undefined;
-  const rel = popup ? "noopener noreferrer" : undefined;
+  const target = shouldPopup ? "_blank" : undefined;
+  const rel = shouldPopup ? "noopener noreferrer" : undefined;
 
   return (
-    <a {...rest} href={url} rel={rel} target={target} onClick={handleClick}>
+    <a
+      {...rest}
+      download={download}
+      href={url}
+      rel={rel}
+      target={target}
+      onClick={handleClick}
+    >
       {children}
     </a>
   );
@@ -60,6 +76,8 @@ export const UnstyledLink = ({ children, external, onClick, url, ...rest }) => {
 UnstyledLink.propTypes = {
   /** The content to display inside the link */
   children: PropTypes.node,
+  /** Instructs the browser to download the file */
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /** Makes the link open in a new tab */
   external: PropTypes.bool,
   /** Callback when a link is clicked */

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -14,6 +14,7 @@ const internal = "/about";
 const sendMessageLink = "sendMessageLink";
 const popupLink = "popupLink";
 const defaultLink = "defaultLink";
+const downloadLink = "downloadLink";
 
 // TestComponent is here mostly so that we can use the useParent hook to access setParent
 function TestComponent({ children, embedded }) {
@@ -30,25 +31,58 @@ function TestComponent({ children, embedded }) {
 }
 
 describe.each`
-  url         | externalProp | expected
-  ${host}     | ${undefined} | ${sendMessageLink}
-  ${host}     | ${true}      | ${popupLink}
-  ${host}     | ${false}     | ${sendMessageLink}
-  ${external} | ${undefined} | ${popupLink}
-  ${external} | ${true}      | ${popupLink}
-  ${external} | ${false}     | ${defaultLink}
-  ${internal} | ${undefined} | ${defaultLink}
-  ${internal} | ${true}      | ${popupLink}
-  ${internal} | ${false}     | ${defaultLink}
+  url         | externalProp | downloadProp | expected
+  ${host}     | ${undefined} | ${undefined} | ${sendMessageLink}
+  ${host}     | ${undefined} | ${true}      | ${downloadLink}
+  ${host}     | ${undefined} | ${false}     | ${sendMessageLink}
+  ${host}     | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${host}     | ${true}      | ${undefined} | ${popupLink}
+  ${host}     | ${true}      | ${true}      | ${downloadLink}
+  ${host}     | ${true}      | ${false}     | ${popupLink}
+  ${host}     | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${host}     | ${false}     | ${undefined} | ${sendMessageLink}
+  ${host}     | ${false}     | ${true}      | ${downloadLink}
+  ${host}     | ${false}     | ${false}     | ${sendMessageLink}
+  ${host}     | ${false}     | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${undefined} | ${undefined} | ${popupLink}
+  ${external} | ${undefined} | ${true}      | ${downloadLink}
+  ${external} | ${undefined} | ${false}     | ${popupLink}
+  ${external} | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${true}      | ${undefined} | ${popupLink}
+  ${external} | ${true}      | ${true}      | ${downloadLink}
+  ${external} | ${true}      | ${false}     | ${popupLink}
+  ${external} | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${false}     | ${undefined} | ${defaultLink}
+  ${external} | ${false}     | ${true}      | ${downloadLink}
+  ${external} | ${false}     | ${false}     | ${defaultLink}
+  ${external} | ${false}     | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${undefined} | ${undefined} | ${defaultLink}
+  ${internal} | ${undefined} | ${true}      | ${downloadLink}
+  ${internal} | ${undefined} | ${false}     | ${defaultLink}
+  ${internal} | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${true}      | ${undefined} | ${popupLink}
+  ${internal} | ${true}      | ${true}      | ${downloadLink}
+  ${internal} | ${true}      | ${false}     | ${popupLink}
+  ${internal} | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${false}     | ${undefined} | ${defaultLink}
+  ${internal} | ${false}     | ${true}      | ${downloadLink}
+  ${internal} | ${false}     | ${false}     | ${defaultLink}
+  ${internal} | ${false}     | ${"a.txt"}   | ${downloadLink}
 `(
   "in embedded mode, when url is $url and the external prop is $externalProp",
-  ({ expected, externalProp, url }) => {
+  ({ downloadProp, expected, externalProp, url }) => {
     test(`will ${expected}`, () => {
       let props = { url };
       if (typeof externalProp === "boolean") {
         props = {
           ...props,
           external: externalProp,
+        };
+      }
+      if (downloadProp) {
+        props = {
+          ...props,
+          download: downloadProp,
         };
       }
 
@@ -59,48 +93,97 @@ describe.each`
       );
 
       switch (expected) {
-        case "sendMessageLink":
+        case sendMessageLink:
           fireEvent.click(screen.getByRole("link"));
           expect(sendMessage).toHaveBeenCalledWith({
             event: "navigate",
             url,
           });
+          expect(screen.getByRole("link")).not.toHaveAttribute("rel");
+          expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
           break;
-        case "popupLink":
+        case popupLink:
           expect(screen.getByRole("link")).toHaveAttribute(
             "rel",
             "noopener noreferrer"
           );
           expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
+          expect(sendMessage).not.toHaveBeenCalled();
           break;
-        case "defaultLink":
+        case downloadLink:
           expect(screen.getByRole("link")).not.toHaveAttribute("rel");
           expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).toHaveAttribute(
+            "download",
+            typeof downloadProp === "string" ? downloadProp : ""
+          );
+          expect(sendMessage).not.toHaveBeenCalled();
+          break;
+        case defaultLink:
+          expect(screen.getByRole("link")).not.toHaveAttribute("rel");
+          expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
+          expect(sendMessage).not.toHaveBeenCalled();
       }
     });
   }
 );
 
 describe.each`
-  url         | externalProp | expected
-  ${host}     | ${undefined} | ${defaultLink}
-  ${host}     | ${true}      | ${popupLink}
-  ${host}     | ${false}     | ${defaultLink}
-  ${external} | ${undefined} | ${defaultLink}
-  ${external} | ${true}      | ${popupLink}
-  ${external} | ${false}     | ${defaultLink}
-  ${internal} | ${undefined} | ${defaultLink}
-  ${internal} | ${true}      | ${popupLink}
-  ${internal} | ${false}     | ${defaultLink}
+  url         | externalProp | downloadProp | expected
+  ${host}     | ${undefined} | ${undefined} | ${defaultLink}
+  ${host}     | ${undefined} | ${true}      | ${downloadLink}
+  ${host}     | ${undefined} | ${false}     | ${defaultLink}
+  ${host}     | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${host}     | ${true}      | ${undefined} | ${popupLink}
+  ${host}     | ${true}      | ${true}      | ${downloadLink}
+  ${host}     | ${true}      | ${false}     | ${popupLink}
+  ${host}     | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${host}     | ${false}     | ${undefined} | ${defaultLink}
+  ${host}     | ${false}     | ${true}      | ${downloadLink}
+  ${host}     | ${false}     | ${false}     | ${defaultLink}
+  ${host}     | ${false}     | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${undefined} | ${undefined} | ${defaultLink}
+  ${external} | ${undefined} | ${true}      | ${downloadLink}
+  ${external} | ${undefined} | ${false}     | ${defaultLink}
+  ${external} | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${true}      | ${undefined} | ${popupLink}
+  ${external} | ${true}      | ${true}      | ${downloadLink}
+  ${external} | ${true}      | ${false}     | ${popupLink}
+  ${external} | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${external} | ${false}     | ${undefined} | ${defaultLink}
+  ${external} | ${false}     | ${true}      | ${downloadLink}
+  ${external} | ${false}     | ${false}     | ${defaultLink}
+  ${external} | ${false}     | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${undefined} | ${undefined} | ${defaultLink}
+  ${internal} | ${undefined} | ${true}      | ${downloadLink}
+  ${internal} | ${undefined} | ${false}     | ${defaultLink}
+  ${internal} | ${undefined} | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${true}      | ${undefined} | ${popupLink}
+  ${internal} | ${true}      | ${true}      | ${downloadLink}
+  ${internal} | ${true}      | ${false}     | ${popupLink}
+  ${internal} | ${true}      | ${"a.txt"}   | ${downloadLink}
+  ${internal} | ${false}     | ${undefined} | ${defaultLink}
+  ${internal} | ${false}     | ${true}      | ${downloadLink}
+  ${internal} | ${false}     | ${false}     | ${defaultLink}
+  ${internal} | ${false}     | ${"a.txt"}   | ${downloadLink}
 `(
   "in standalone mode, when url is $url and the external prop is $externalProp",
-  ({ expected, externalProp, url }) => {
+  ({ downloadProp, expected, externalProp, url }) => {
     test(`will ${expected}`, () => {
       let props = { url };
       if (typeof externalProp === "boolean") {
         props = {
           ...props,
           external: externalProp,
+        };
+      }
+      if (downloadProp) {
+        props = {
+          ...props,
+          download: downloadProp,
         };
       }
 
@@ -117,6 +200,9 @@ describe.each`
             event: "navigate",
             url,
           });
+          expect(screen.getByRole("link")).not.toHaveAttribute("rel");
+          expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
           break;
         case "popupLink":
           expect(screen.getByRole("link")).toHaveAttribute(
@@ -124,10 +210,23 @@ describe.each`
             "noopener noreferrer"
           );
           expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
+          expect(sendMessage).not.toHaveBeenCalled();
+          break;
+        case downloadLink:
+          expect(screen.getByRole("link")).not.toHaveAttribute("rel");
+          expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).toHaveAttribute(
+            "download",
+            typeof downloadProp === "string" ? downloadProp : ""
+          );
+          expect(sendMessage).not.toHaveBeenCalled();
           break;
         case "defaultLink":
           expect(screen.getByRole("link")).not.toHaveAttribute("rel");
           expect(screen.getByRole("link")).not.toHaveAttribute("target");
+          expect(screen.getByRole("link")).not.toHaveAttribute("download");
+          expect(sendMessage).not.toHaveBeenCalled();
       }
     });
   }


### PR DESCRIPTION
1. White background for `plain`, `outline` and `brandOutline` buttons. This makes them usable against the gray background variation.
2. Support the `download` attribute on anchor tag to instruct a browser to download the URL instead of navigating to it.