### PR TITLE
Add support for building an alternate page style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ## 1.3.0 - 2020-07-15
 
+### Enhancements
+
 - Plain and outline buttons now have a white background
   ([#150](https://github.com/envoy/polarwind/pull/150))
 - Button and Link accept a download prop

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,13 +6,23 @@
 
 ### Enhancements
 
+- Add a shadowed variant to Card for use on a "transparent" Page.
+- Add a secondary variant to Heading and Display Text
+- Add a transparent variant to Page. A transparent Page is a page without the usual
+  card-like container.
+
 ### Bug fixes
+
+- Fix items in a Stack with `fillEvenly` distribution to have equal size regardless of the
+  content inside each item.
 
 ### Documentation
 
 ### Development workflow
 
 ### Dependency upgrades
+
+- Upgraded Tailwind to 1.5.1
 
 ### Code quality
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-standard": "^20.0.0",
-    "tailwindcss": "^1.4.4",
+    "tailwindcss": "^1.5.1",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -8,9 +8,12 @@ const cx = classnames.bind(styles);
  * Cards are used to group similar concepts and tasks together to make Envoy easier for
  * users to scan, read, and get things done.
  */
-export const Card = ({ children }) => {
+export const Card = ({ children, shadow }) => {
   const className = cx({
     Card: true,
+    // workaround a tailwind or postcss bug where class names cannot be the same as the
+    // @apply rule https://github.com/tailwindcss/tailwindcss/issues/2036
+    shadowed: shadow,
   });
   return <div className={className}>{children}</div>;
 };
@@ -18,4 +21,6 @@ export const Card = ({ children }) => {
 Card.propTypes = {
   /** Inner content of the card */
   children: PropTypes.node,
+  /** The shadow variant of card */
+  shadow: PropTypes.bool,
 };

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,3 +1,7 @@
 .Card {
   @apply m-0 bg-white border border-arctic rounded-lg p-4;
 }
+
+.shadowed {
+  @apply shadow border-transparent;
+}

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -44,3 +44,15 @@ import { User } from "../../icons";
 ### Default card
 
 Use when you have a simple message to communicate to merchants that doesn't require any secondary steps.
+
+### Shadowed card
+
+Use when using a card on a transparent Page
+
+<Preview>
+  <Story name="Shadow">
+    <div style={{ backgroundColor: "#f6f6f9", padding: "20px" }}>
+      <Card shadow>A shadowed card</Card>
+    </div>
+  </Story>
+</Preview>

--- a/src/components/DisplayText/DisplayText.js
+++ b/src/components/DisplayText/DisplayText.js
@@ -10,8 +10,13 @@ const cx = classnames.bind(styles);
  * goal is visual storytelling. For example, use display text to convince or reassure
  * users such as in marketing content or to capture attention during onboarding.
  */
-export const DisplayText = ({ children, element = "p", size = "medium" }) => {
-  const className = cx("DisplayText", size);
+export const DisplayText = ({
+  children,
+  element = "p",
+  secondary,
+  size = "medium",
+}) => {
+  const className = cx({ secondary }, "DisplayText", size);
   return createElement(element, { className }, <span>{children}</span>);
 };
 
@@ -20,6 +25,8 @@ DisplayText.propTypes = {
   children: PropTypes.node,
   /** Name of the element to use for text */
   element: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6", "p"]),
+  /** Subdued display text */
+  secondary: PropTypes.bool,
   /** Size of the text */
   size: PropTypes.oneOf(["small", "medium", "large", "extraLarge"]),
 };

--- a/src/components/DisplayText/DisplayText.module.css
+++ b/src/components/DisplayText/DisplayText.module.css
@@ -33,3 +33,7 @@
     @apply align-lg;
   }
 }
+
+.secondary {
+  @apply font-normal;
+}

--- a/src/components/DisplayText/DisplayText.stories.mdx
+++ b/src/components/DisplayText/DisplayText.stories.mdx
@@ -6,6 +6,8 @@ import {
   Preview,
 } from "@storybook/addon-docs/blocks";
 import { DisplayText } from "./DisplayText";
+import { Heading } from "../Heading";
+import { Stack } from "../Stack";
 
 <Meta
   title="Components | Titles and text / Display text"
@@ -65,5 +67,25 @@ Use for text that would otherwise use body text, but that needs to scale with ot
     <DisplayText size="small">
       I'm sorry Dave, I'm afraid I can't do that
     </DisplayText>
+  </Story>
+</Preview>
+
+### Secondary display text
+
+Use when display text needs a lighter treatment, for example, when it is in proximity with
+a header.
+
+<Preview>
+  <Story name="Secondary">
+    <Card>
+      <Stack vertical>
+        <Heading element="h3" secondary>
+          Total hours saved
+        </Heading>
+        <DisplayText size="extraLarge" secondary>
+          50
+        </DisplayText>
+      </Stack>
+    </Card>
   </Story>
 </Preview>

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -9,8 +9,8 @@ const cx = classnames.bind(styles);
  * Headings are used as the titles of each major section of a page in the interface. For
  * example, card components generally use headings as their title.
  */
-export const Heading = ({ children, element = "h2" }) => {
-  const className = cx("Heading");
+export const Heading = ({ children, element = "h2", secondary }) => {
+  const className = cx({ Heading: true, secondary });
   return createElement(element, { className }, <span>{children}</span>);
 };
 
@@ -19,4 +19,6 @@ Heading.propTypes = {
   children: PropTypes.node,
   /** Name of the element to use for text */
   element: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6", "p"]),
+  /** Subdued header */
+  secondary: PropTypes.bool,
 };

--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -5,3 +5,7 @@
     @apply align-base;
   }
 }
+
+.secondary {
+  @apply text-carbon-65% font-medium;
+}

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -5,6 +5,9 @@ import {
   Description,
   Preview,
 } from "@storybook/addon-docs/blocks";
+import { Card } from "../Card";
+import { Stack } from "../Stack";
+import { DisplayText } from "../DisplayText";
 import { Heading } from "./Heading";
 
 <Meta title="Components | Titles and text / Heading" component={Heading} />
@@ -26,3 +29,20 @@ import { Heading } from "./Heading";
 ### Default heading
 
 Use for the title of each top-level page section.
+
+### Secondary heading
+
+Use when it's more important to draw focus on the content.
+
+<Preview>
+  <Story name="Secondary">
+    <Card>
+      <Stack vertical>
+        <Heading element="h3" secondary>
+          Total hours saved
+        </Heading>
+        <DisplayText size="extraLarge">50</DisplayText>
+      </Stack>
+    </Card>
+  </Story>
+</Preview>

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -11,13 +11,25 @@ const cx = classnames.bind(styles);
  * Use to build the outer wrapper of a page, including the page title and associated
  * actions.
  */
-export const Page = ({ breadcrumbs, children, title, titleAction }) => {
+export const Page = ({
+  breadcrumbs,
+  children,
+  title,
+  titleAction,
+  transparent,
+}) => {
   const embedded = useContext(EmbeddedContext);
 
   const className = cx({
     Page: true,
     standalone: !embedded,
+    transparent,
     withHeader: title,
+  });
+
+  const wrapperClassName = cx({
+    transparent,
+    wrapper: true,
   });
 
   const headerMarkup = title && (
@@ -38,7 +50,7 @@ export const Page = ({ breadcrumbs, children, title, titleAction }) => {
   return embedded ? (
     <PageMarkup data-iframe-height />
   ) : (
-    <div className={styles.wrapper} data-iframe-height>
+    <div className={wrapperClassName} data-iframe-height>
       <PageMarkup />
     </div>
   );
@@ -58,6 +70,8 @@ Page.propTypes = {
   title: PropTypes.string,
   /** Actions to present on the right of the title */
   titleAction: PropTypes.node,
+  /** Alternate page design */
+  transparent: PropTypes.bool,
 };
 
 Page.Header = Header;

--- a/src/components/Page/Page.module.css
+++ b/src/components/Page/Page.module.css
@@ -11,7 +11,7 @@
 }
 
 .standalone {
-  @apply shadow-page flex-auto;
+  @apply shadow-medium flex-auto;
 }
 
 .Header {

--- a/src/components/Page/Page.module.css
+++ b/src/components/Page/Page.module.css
@@ -1,9 +1,17 @@
-.wrapper {
-  @apply bg-arctic-50% p-8 min-h-full flex flex-col;
-}
-
 .Page {
   @apply bg-white px-8 pb-8 rounded-page;
+}
+
+.transparent {
+  @apply bg-transparent;
+}
+
+.wrapper {
+  @apply bg-arctic-50% p-8 min-h-full flex flex-col;
+
+  .transparent {
+    @apply p-0;
+  }
 }
 
 .withHeader {
@@ -11,7 +19,11 @@
 }
 
 .standalone {
-  @apply shadow-medium flex-auto;
+  @apply flex-auto;
+
+  &:not(.transparent) {
+    @apply shadow-medium;
+  }
 }
 
 .Header {

--- a/src/components/Page/Page.stories.mdx
+++ b/src/components/Page/Page.stories.mdx
@@ -7,13 +7,16 @@ import {
 } from "@storybook/addon-docs/blocks";
 import { Button } from "../Button";
 import { ButtonGroup } from "../ButtonGroup";
+import { Card } from "../Card";
+import { DisplayText } from "../DisplayText";
+import { EmbeddedContext } from "../../utils/embedded";
 import { FormLayout } from "../FormLayout";
+import { Heading } from "../Heading";
 import { Page } from "./Page";
 import { Select } from "../Select";
 import { Stack } from "../Stack";
 import { Tabs } from "../Tabs";
 import { TextField } from "../TextField";
-import { EmbeddedContext } from "../../utils/embedded";
 
 <Meta title="Components | Structure / Page" component={Page} />
 
@@ -123,5 +126,62 @@ breadcrumb and title actions that you define will not be rendered too.
         />
       </FormLayout>
     </Page>
+  </Story>
+</Preview>
+
+### Transparent page
+
+An alternate variant of pages are the transparent pages, typically found on pages where
+the primary intent is data display. These pages will not be wrapped in a shadowed white
+background.
+
+<Preview>
+  <Story name="Transparent">
+    <div style={{ backgroundColor: "#f6f6f9", paddingTop: "2rem" }}>
+      <Page transparent>
+        <Stack distribution="fillEvenly" spacing="loose">
+          <Card shadow>
+            <Stack vertical>
+              <Heading element="h3" secondary>
+                Deliveries scanned
+              </Heading>
+              <DisplayText size="extraLarge" secondary>
+                57
+              </DisplayText>
+            </Stack>
+          </Card>
+          <Card shadow>
+            <Stack vertical>
+              <Heading element="h3" secondary>
+                Avg deliveries/week
+              </Heading>
+              <DisplayText size="extraLarge" secondary>
+                57
+              </DisplayText>
+            </Stack>
+          </Card>
+          <Card shadow>
+            <Stack vertical>
+              <Heading element="h3" secondary>
+                Total hours saved
+              </Heading>
+              <DisplayText size="extraLarge" secondary>
+                50
+              </DisplayText>
+            </Stack>
+          </Card>
+          <Card shadow>
+            <Stack vertical>
+              <Heading element="h3" secondary>
+                Avg time to pick-up
+              </Heading>
+              <DisplayText size="extraLarge" secondary>
+                35h:45m
+              </DisplayText>
+            </Stack>
+          </Card>
+        </Stack>
+      </Page>
+    </div>
   </Story>
 </Preview>

--- a/src/components/Page/Page.stories.mdx
+++ b/src/components/Page/Page.stories.mdx
@@ -140,46 +140,50 @@ background.
     <div style={{ backgroundColor: "#f6f6f9", paddingTop: "2rem" }}>
       <Page transparent>
         <Stack distribution="fillEvenly" spacing="loose">
-          <Card shadow>
-            <Stack vertical>
-              <Heading element="h3" secondary>
-                Deliveries scanned
-              </Heading>
-              <DisplayText size="extraLarge" secondary>
-                57
-              </DisplayText>
-            </Stack>
-          </Card>
-          <Card shadow>
-            <Stack vertical>
-              <Heading element="h3" secondary>
-                Avg deliveries/week
-              </Heading>
-              <DisplayText size="extraLarge" secondary>
-                57
-              </DisplayText>
-            </Stack>
-          </Card>
-          <Card shadow>
-            <Stack vertical>
-              <Heading element="h3" secondary>
-                Total hours saved
-              </Heading>
-              <DisplayText size="extraLarge" secondary>
-                50
-              </DisplayText>
-            </Stack>
-          </Card>
-          <Card shadow>
-            <Stack vertical>
-              <Heading element="h3" secondary>
-                Avg time to pick-up
-              </Heading>
-              <DisplayText size="extraLarge" secondary>
-                35h:45m
-              </DisplayText>
-            </Stack>
-          </Card>
+          <Stack distribution="fillEvenly" spacing="loose" wrap={false}>
+            <Card shadow>
+              <Stack vertical>
+                <Heading element="h3" secondary>
+                  Deliveries scanned
+                </Heading>
+                <DisplayText size="extraLarge" secondary>
+                  57
+                </DisplayText>
+              </Stack>
+            </Card>
+            <Card shadow>
+              <Stack vertical>
+                <Heading element="h3" secondary>
+                  Avg deliveries/week
+                </Heading>
+                <DisplayText size="extraLarge" secondary>
+                  57
+                </DisplayText>
+              </Stack>
+            </Card>
+          </Stack>
+          <Stack distribution="fillEvenly" spacing="loose" wrap={false}>
+            <Card shadow>
+              <Stack vertical>
+                <Heading element="h3" secondary>
+                  Total hours saved
+                </Heading>
+                <DisplayText size="extraLarge" secondary>
+                  50
+                </DisplayText>
+              </Stack>
+            </Card>
+            <Card shadow>
+              <Stack vertical>
+                <Heading element="h3" secondary>
+                  Avg time to pick-up
+                </Heading>
+                <DisplayText size="extraLarge" secondary>
+                  35h:45m
+                </DisplayText>
+              </Stack>
+            </Card>
+          </Stack>
         </Stack>
       </Page>
     </div>

--- a/src/components/Stack/Stack.module.css
+++ b/src/components/Stack/Stack.module.css
@@ -35,14 +35,14 @@
 }
 
 .distributionFill {
-  .Item {
+  & > .Item {
     @apply flex-auto;
   }
 }
 
 .distributionFillEvenly {
-  .Item {
-    @apply flex-grow flex-shrink-0;
+  & > .Item {
+    @apply flex-fill min-w-min;
   }
 }
 

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -6,7 +6,7 @@
   }
 
   span {
-    @apply translate-x-0 shadow inline-block h-6 w-6 rounded-full bg-white transform transition ease-in-out duration-200;
+    @apply translate-x-0 shadow-toggle inline-block h-6 w-6 rounded-full bg-white transform transition ease-in-out duration-200;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -78,8 +78,11 @@ module.exports = {
     // which is why the best place to define it is by overriding the entire boxShadow
     // theme
     boxShadow: (theme) => ({
+      default: "0px 1px 2px rgba(0, 0, 0, 0.08)",
       none: "none",
-      default: "0px 2px 6px rgba(0, 0, 0, 0.48)",
+      medium: "0px 2px 4px rgba(0, 0, 0, 0.08)",
+      large: "0px 4px 8px rgba(0, 0, 0, 0.12)",
+      xl: "0px 4px 16px rgba(0, 0, 0, 0.16)",
       outline: `0 0 0 2px ${theme("colors.arctic.default")}`,
       "outline-brand": `0 0 0 2px ${rgba(theme("colors.brand.default"), 0.3)}`,
       "outline-toggle": `0 0 0 2px ${theme("colors.carbon.20%")}`,
@@ -96,7 +99,7 @@ module.exports = {
         "inset 0px 1px 1.5px rgba(0, 0, 0, 0.26)",
         "inset 0px -1px 1.5px rgba(0, 0, 0, 0.1)",
       ].join(),
-      page: "0px 2px 4px rgba(0, 0, 0, 0.08)",
+      toggle: "0px 2px 6px rgba(0, 0, 0, 0.48)",
     }),
     extend: {
       borderRadius: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -108,7 +108,10 @@ module.exports = {
         6: "6px",
       },
       flex: {
-        "0": "0 0 auto",
+        fill: "1 0",
+      },
+      minWidth: {
+        min: "min-content",
       },
       opacity: {
         40: ".4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5479,6 +5479,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+"chalk@^3.0.0 || ^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
@@ -16154,16 +16162,16 @@ table@^5.2.3, table@^5.4.6:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tailwindcss@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.4.4.tgz#a866f281f99ee7058fa3301ef0ce34b16141deb6"
-  integrity sha512-49Hy/+WnqQhxtGGjcGlhRlE7+hooX2A0/JOeJnA78fCEqDRlhURWujHY05aCl+lJ6G2qQ+1wlQTg4PqMPUcFVA==
+tailwindcss@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.5.1.tgz#a3eb10024f8e10786b8b6badcf9665b013bd03ee"
+  integrity sha512-mBOxIk+U+9xECC6wllWiupPVfLuwTDvHb4d+8XTdZ8oYrZEH+NpFSlbATF5xWuCJQxDOZ1Dz7C0KN5tylcFhFg==
   dependencies:
     "@fullhuman/postcss-purgecss" "^2.1.2"
     autoprefixer "^9.4.5"
     browserslist "^4.12.0"
     bytes "^3.0.0"
-    chalk "^4.0.0"
+    chalk "^3.0.0 || ^4.0.0"
     color "^3.1.2"
     detective "^5.2.0"
     fs-extra "^8.0.0"


### PR DESCRIPTION
Regular Polarwind pages look like this

![image](https://user-images.githubusercontent.com/269/87736833-06b48a00-c78e-11ea-9b65-47180016e039.png)

This PR adds support for an alternate page design, typically used for the display of metrics

![image](https://user-images.githubusercontent.com/269/87736889-3bc0dc80-c78e-11ea-815f-55f0d8c71af6.png)
