### PR TITLE
Remove babel-plugin-transform-react-remove-prop-types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,9 +9,6 @@
   "sourceType": "unambiguous",
   "env": {
     "production": {
-      "plugins": [
-        ["transform-react-remove-prop-types", { "removeImport": true }]
-      ],
       "comments": false
     }
   }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-react-docgen": "^4.1.0",
     "babel-plugin-react-require": "^3.1.3",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "change-case": "^4.1.1",
     "color": "^3.1.2",
     "dedent": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4067,11 +4067,6 @@ babel-plugin-transform-property-literals@^6.9.4:
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-react-remove-prop-types@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
-  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
-
 babel-plugin-transform-regexp-constructors@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz#58b7775b63afcf33328fae9a5f88fbd4fb0b4965"


### PR DESCRIPTION
Leave propTypes in so that IDEs can autocomplete props