### PR TITLE
Optimize compiled output

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,11 +6,17 @@
 
 ### Enhancements
 
+- The Select component has been rebuilt from the ground up without any breaking changes.
+  The options dropdown is now styled to match the design system.
+
 ### Bug fixes
 
 ### Documentation
 
 ### Development workflow
+
+- Removed a babel plugin that stripped proptypes from the production build. This should
+  help IDEs autocomplete props.
 
 ### Dependency upgrades
 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,6 @@
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
     "@percy/storybook": "^3.3.0",
-    "@react-aria/button": "^3.2.1",
-    "@react-aria/listbox": "^3.2.0",
-    "@react-aria/select": "^3.2.0",
-    "@react-stately/data": "^3.1.0",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-node-resolve": "^7.1.3",
@@ -118,6 +114,10 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@react-aria/button": "^3.2.1",
+    "@react-aria/listbox": "^3.2.0",
+    "@react-aria/select": "^3.2.0",
+    "@react-stately/data": "^3.1.0",
     "classnames": "^2.2.6",
     "react-autosize-textarea": "^7.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envoy/polarwind",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Envoy's product component library",
   "main": "index.cjs.js",
   "module": "index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,20 +6,21 @@ const postcss = require("rollup-plugin-postcss");
 const packageJson = require("./package.json");
 const { generateScopedName } = require("./src/plugins/polarisNamingStrategy");
 
+const externalPackages = [
+  "react",
+  "classnames",
+  "react-autosize-textarea",
+  "react-is",
+  "prop-types",
+  "object-assign",
+];
+
 module.exports = [
   {
-    external: [
-      "react",
-      "classnames",
-      "react-autosize-textarea",
-      "@react-aria/select",
-      "@react-aria/button",
-      "@react-aria/listbox",
-      "@react-aria/button",
-      "@react-aria/listbox",
-      "@react-aria/select",
-      "@react-stately/data",
-    ],
+    external: (id) =>
+      externalPackages.includes(id) ||
+      id.includes("react-aria") ||
+      id.includes("react-stately"),
     input: "src/index.js",
     plugins: [
       resolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,18 @@ const { generateScopedName } = require("./src/plugins/polarisNamingStrategy");
 
 module.exports = [
   {
-    external: ["react", "classnames", "react-autosize-textarea"],
+    external: [
+      "react",
+      "classnames",
+      "react-autosize-textarea",
+      "@react-aria/select",
+      "@react-aria/button",
+      "@react-aria/listbox",
+      "@react-aria/button",
+      "@react-aria/listbox",
+      "@react-aria/select",
+      "@react-stately/data",
+    ],
     input: "src/index.js",
     plugins: [
       resolve(),


### PR DESCRIPTION
Move react-aria and react-stately packages out of devDependencies and out of the compiled index.esm.js

### Before
```
1410646 index.esm.js
1413141 index.cjs.js
```

### After
```
96243 index.cjs.js
94490 index.esm.js
```
