### PR TITLE
Fix unable to type into an uncontrolled text field

### DIFF
--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/bind";
 import PropTypes from "prop-types";
+import { useState } from "react";
 import TextareaAutosize from "react-autosize-textarea";
 import { Labeled } from "../Labeled";
 import styles from "./TextField.module.css";
@@ -26,6 +27,11 @@ export const TextField = ({
   type = "text",
   value,
 }) => {
+  // figure out if the TextField started off without setting a value prop, making it an
+  // uncontrolled input field. this value doesn't change during the lifetime of the
+  // component.
+  const [isControlled] = useState(value ?? false);
+
   // == LABEL ==
   labelHidden = labelHidden ?? type === "search";
 
@@ -63,8 +69,9 @@ export const TextField = ({
     onFocus: handleFocus,
     placeholder: labelHidden ? label : undefined,
     type,
-    value: value || "",
+    ...(isControlled && { value }),
   };
+
   const inputMarkup = multiline ? (
     <TextareaAutosize
       {...inputProps}

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -27,7 +27,7 @@ export const TextField = ({
   type = "text",
   value,
 }) => {
-  // figure out if the TextField started off without setting a value prop, making it an
+  // remember if the TextField started off without setting a value prop, making it an
   // uncontrolled input field. this value doesn't change during the lifetime of the
   // component.
   const [isControlled] = useState(value ?? false);

--- a/src/components/TextField/tests/TextField.test.js
+++ b/src/components/TextField/tests/TextField.test.js
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { TextField } from "../TextField";
+
+test("can type in an uncontrolled text field", () => {
+  render(<TextField label="test" />);
+  const input = screen.getByLabelText("test");
+  fireEvent.change(input, { target: { value: "uncontrolled" } });
+  expect(input).toHaveValue("uncontrolled");
+  fireEvent.change(input, { target: { value: "more" } });
+  expect(input).toHaveValue("more");
+});
+
+test("can type in a controlled text field", () => {
+  function ControlledTextField() {
+    const [value, setValue] = useState();
+    return <TextField label="test" value={value} onChange={setValue} />;
+  }
+  render(<ControlledTextField />);
+  const input = screen.getByLabelText("test");
+  fireEvent.change(input, { target: { value: "controlled" } });
+  expect(input).toHaveValue("controlled");
+  fireEvent.change(input, { target: { value: "more" } });
+  expect(input).toHaveValue("more");
+});


### PR DESCRIPTION
This was introduced from a bugfix that was trying to fix react warning us about an input going from uncontrolled to controlled