### PR TITLE
Scroll long selects

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+- Scroll long Select lists
+
 ### Bug fixes
 
 - Updated the default brand color to the right value
@@ -14,6 +16,8 @@
 ### Documentation
 
 ### Development workflow
+
+- Upgraded Storybook to 6.1
 
 ### Dependency upgrades
 

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -24,6 +24,10 @@
 
 .OptionList {
   @apply shadow-large rounded-md p-1 bg-white;
+
+  /** allow long lists to scroll */
+  max-height: calc(100vh - 6rem);
+  @apply overflow-y-auto;
 }
 
 .Option {

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -229,3 +229,30 @@ Also supports a `disabled` attribute.
     </FormLayout>
   </Story>
 </Preview>
+
+### Scrolling long menus
+
+When the viewport cannot contain all menu items, the list presents a scrollable list
+(resize the window to be short to test).
+
+<Preview>
+  <Story name="Scrolling list">
+    <Select
+      label="Month"
+      options={[
+        { label: "January", value: "1" },
+        { label: "February", value: "2" },
+        { label: "March", value: "3" },
+        { label: "April", value: "4" },
+        { label: "May", value: "5" },
+        { label: "June", value: "6" },
+        { label: "July", value: "7" },
+        { label: "August", value: "8" },
+        { label: "September", value: "9" },
+        { label: "October", value: "10" },
+        { label: "November", value: "11" },
+        { label: "December", value: "12" },
+      ]}
+    />
+  </Story>
+</Preview>


### PR DESCRIPTION
Long `Select` lists will now grow to the maximum viewport height before presenting a scrollbar.

![image](https://user-images.githubusercontent.com/269/101067859-e32b8980-354c-11eb-897d-8a0a10dd0c9f.png)
