### PR TITLE
Upgrade Tailwind to 1.9 series

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-standard": "^20.0.0",
-    "tailwindcss": "^1.7.4",
+    "tailwindcss": "^1.9.6",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {

--- a/src/plugins/fontMetrics.js
+++ b/src/plugins/fontMetrics.js
@@ -47,7 +47,7 @@ module.exports = function ({
       _.map(capHeights, ([modifier, capHeight]) => {
         let selector;
 
-        if (config("corePlugins.fontSize") === false) {
+        if (config("corePlugins").indexOf("fontSize") < 0) {
           selector = ["text", modifier];
         } else {
           assert(infix, "infix required if fontSize corePlugin is enabled");
@@ -70,7 +70,7 @@ module.exports = function ({
         return _.map(capHeights, ([fontSizeModifier, capHeight]) => {
           let selector;
 
-          if (config("corePlugins.lineHeight") === false) {
+          if (config("corePlugins").indexOf("lineHeight") < 0) {
             selector = ["leading", fontSizeModifier, modifier];
           } else {
             assert(infix, "infix required if lineHeight corePlugin is enabled");

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -263,6 +263,7 @@ module.exports = {
     divideOpacity: false,
   },
   purge: {
+    mode: "layers",
     content: ["./src/**/*.js"],
     options: {
       ...(process.env.STORYBOOK && {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,4 @@
 const hexRgb = require("hex-rgb");
-const config = require("tailwindcss/defaultConfig");
 
 function rgba(hex, alpha) {
   const { blue, green, red } = hexRgb(hex);
@@ -240,9 +239,9 @@ module.exports = {
     }),
   },
   variants: {
-    borderRadius: [...config.variants.borderRadius, "first", "last"],
-    borderWidth: [...config.variants.borderWidth, "hover"],
-    margin: [...config.variants.margin, "first"],
+    borderRadius: ({ after }) => after(["first", "last"]),
+    borderWidth: ({ after }) => after(["hover"]),
+    margin: ({ after }) => after(["first"]),
   },
   plugins: [
     require("@tailwindcss/custom-forms"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -15141,10 +15141,10 @@ table@^5.2.3, table@^5.4.6:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tailwindcss@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.7.4.tgz#3992c5cda50887da3f5e108388a58f199aa52a40"
-  integrity sha512-DEQ87VQdMkbjd+CpuAbcTS2lD/4zkTYsEadzY1bAynNgsKncN9bm6JgiPN4Bv7WT+620kvvHvHlSPr074aBsRA==
+tailwindcss@^1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
+  integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==
   dependencies:
     "@fullhuman/postcss-purgecss" "^2.1.2"
     autoprefixer "^9.4.5"
@@ -15154,7 +15154,8 @@ tailwindcss@^1.7.4:
     color "^3.1.2"
     detective "^5.2.0"
     fs-extra "^8.0.0"
-    lodash "^4.17.15"
+    html-tags "^3.1.0"
+    lodash "^4.17.20"
     node-emoji "^1.8.1"
     normalize.css "^8.0.1"
     object-hash "^2.0.3"


### PR DESCRIPTION
Main reason is to be able to use presets. See https://github.com/envoy/tailwind
