### PR TITLE
Upgrade @envoy/tailwind to 1.0.6

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     "at-rule-no-unknown": [
       true,
       {
-        ignoreAtRules: ["tailwind", "screen"],
+        ignoreAtRules: ["tailwind", "screen", "layer"],
       },
     ],
     "at-rule-empty-line-before": [

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,7 @@
 ### Dependency upgrades
 
 - Upgraded to Tailwind 1.9.6
-- Upgraded to @envoy/tailwind 1.0.3
+- Upgraded to @envoy/tailwind 1.0.6
 
 ### Code quality
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,7 @@
 ### Dependency upgrades
 
 - Upgraded to Tailwind 1.9.6
-- Upgraded to @envoy/tailwind 1.0.2
+- Upgraded to @envoy/tailwind 1.0.3
 
 ### Code quality
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@storybook/addon-links": "^6.1.9",
     "@storybook/addons": "^6.1.9",
     "@storybook/react": "^6.1.9",
-    "@tailwindcss/custom-forms": "^0.2.1",
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^10.0.4",
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
-    "@envoy/tailwind": "^1.0.5",
+    "@envoy/tailwind": "^1.0.6",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
-    "@envoy/tailwind": "^1.0.4",
+    "@envoy/tailwind": "^1.0.5",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
-    "@envoy/tailwind": "^1.0.3",
+    "@envoy/tailwind": "^1.0.4",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
-    "@envoy/tailwind": "^1.0.2",
+    "@envoy/tailwind": "^1.0.3",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -1,5 +1,9 @@
 .Banner {
-  @apply p-4 rounded-md grid grid-cols-banner gap-4 max-w-banner;
+  @apply p-4 rounded-md max-w-banner flex space-x-4;
+}
+
+.Icon {
+  @apply w-4;
 }
 
 .success {

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -1,15 +1,16 @@
 .Select {
-  @apply w-full block text-left truncate text-base leading-base-normal;
-
-  &:disabled {
-    @apply pointer-events-none;
-  }
+  @apply leading-base-normal;
 
   span {
     @apply align-base;
   }
 }
 
+/**
+ * We still need this style even though the select has :focus style so that we can
+ * programmatically keep the trigger looking like it's focused when the option list is
+ * open because technically the option list is the one with focus now, not the trigger
+ */
 .triggerFocused {
   @apply shadow-input-gem border-gem-50;
 }

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -58,7 +58,7 @@ export const TextField = ({
     focused,
     "form-input": !multiline,
     "form-textarea": multiline,
-    multiline,
+    input: !multiline, // only apply line-height to normal input. avoids trampling over textarea's line-height: 1.5
   });
 
   const inputProps = {

--- a/src/components/TextField/TextField.module.css
+++ b/src/components/TextField/TextField.module.css
@@ -1,12 +1,10 @@
 .TextField {
-  @apply block w-full;
-
-  /* theme values from the fontMetrics plugin is not availabe in theme() */
-  @apply leading-base-normal;
+  /* placeholder so that it will generate .Polarwind-TextField instead of just .TextField */
 }
 
-.multiline {
-  line-height: 1.5;
+.input {
+  /* theme values from the fontMetrics plugin is not availabe in theme() */
+  @apply leading-base-normal;
 }
 
 .Label {

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -3,7 +3,7 @@
   @apply focus:outline-none focus:shadow-outline-toggle;
 
   span {
-    @apply translate-x-0 shadow-toggle inline-block h-6 w-6 rounded-full bg-white transform transition ease-in-out duration-200;
+    @apply translate-x-0 shadow-toggle inline-block h-6 w-6 rounded-full bg-white transition ease-in-out duration-200;
   }
 }
 

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -1,73 +1,85 @@
 @tailwind base;
 
-html {
-  @apply text-carbon-60;
-}
+@layer base {
+  html {
+    @apply text-carbon-60;
+  }
 
-body {
-  @apply font-sans;
-}
+  body {
+    @apply font-sans;
+  }
 
-@font-face {
-  font-family: "SofiaPro";
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.eot");
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.eot?#iefix")
-      format("embedded-opentype"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.woff2")
-      format("woff2"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.woff")
-      format("woff"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.ttf")
-      format("truetype");
-  font-weight: 400;
-  font-style: normal;
-}
+  @font-face {
+    font-family: "SofiaPro";
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.eot");
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.eot?#iefix")
+        format("embedded-opentype"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.woff2")
+        format("woff2"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.woff")
+        format("woff"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_A_0.ttf")
+        format("truetype");
+    font-weight: 400;
+    font-style: normal;
+  }
 
-@font-face {
-  font-family: "SofiaPro";
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.eot");
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.eot?#iefix")
-      format("embedded-opentype"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.woff2")
-      format("woff2"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.woff")
-      format("woff"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.ttf")
-      format("truetype");
-  font-weight: 400;
-  font-style: italic;
-}
+  @font-face {
+    font-family: "SofiaPro";
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.eot");
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.eot?#iefix")
+        format("embedded-opentype"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.woff2")
+        format("woff2"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.woff")
+        format("woff"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_D_0.ttf")
+        format("truetype");
+    font-weight: 400;
+    font-style: italic;
+  }
 
-@font-face {
-  font-family: "SofiaPro";
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.eot");
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.eot?#iefix")
-      format("embedded-opentype"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.woff2")
-      format("woff2"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.woff")
-      format("woff"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.ttf")
-      format("truetype");
-  font-weight: 500;
-  font-style: normal;
-}
+  @font-face {
+    font-family: "SofiaPro";
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.eot");
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.eot?#iefix")
+        format("embedded-opentype"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.woff2")
+        format("woff2"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.woff")
+        format("woff"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_7_0.ttf")
+        format("truetype");
+    font-weight: 500;
+    font-style: normal;
+  }
 
-@font-face {
-  font-family: "SofiaPro";
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.eot");
-  src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.eot?#iefix")
-      format("embedded-opentype"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.woff2")
-      format("woff2"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.woff")
-      format("woff"),
-    url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.ttf")
-      format("truetype");
-  font-weight: 600;
-  font-style: normal;
+  @font-face {
+    font-family: "SofiaPro";
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.eot");
+    src: url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.eot?#iefix")
+        format("embedded-opentype"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.woff2")
+        format("woff2"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.woff")
+        format("woff"),
+      url("https://envoy-fonts.s3.amazonaws.com/sofia-pro/3AF984_C_0.ttf")
+        format("truetype");
+    font-weight: 600;
+    font-style: normal;
+  }
 }
 
 @tailwind components;
 
 @tailwind utilities;
+
+@layer utilities {
+  .translate-x-0 {
+    transform: translateX(theme("spacing.0"));
+  }
+
+  .translate-x-7 {
+    transform: translateX(theme("spacing.7"));
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -58,9 +58,6 @@ module.exports = {
       flex: {
         fill: "1 0",
       },
-      gridTemplateColumns: {
-        banner: "1rem minmax(auto, 40em)",
-      },
       maxWidth: {
         banner: "624px",
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,4 @@
-const preset = require("@envoy/tailwind");
 const hexRgb = require("hex-rgb");
-const resolveConfig = require("tailwindcss/resolveConfig");
-
-const { theme } = resolveConfig(preset);
 
 function rgba(hex, alpha) {
   const { blue, green, red } = hexRgb(hex);
@@ -10,7 +6,7 @@ function rgba(hex, alpha) {
 }
 
 module.exports = {
-  presets: [preset],
+  presets: [require("@envoy/tailwind")],
   theme: {
     // it's hard to extend boxShadow since it needs the complete string including color,
     // which is why the best place to define it is by overriding the entire boxShadow
@@ -24,35 +20,10 @@ module.exports = {
       outline: `0 0 0 2px ${theme("colors.carbon.10")}`,
       "outline-red-50": `0 0 0 2px ${rgba(theme("colors.red.50"), 0.3)}`,
       "outline-toggle": `0 0 0 2px ${theme("colors.carbon.20")}`,
-      "input-gem": [
-        `0 0 0 1px ${theme("colors.gem.50")}`,
-        `0 1px 4px 0 ${rgba(theme("colors.gem.50"), 0.16)}`,
-      ].join(),
-      "input-papaya": [
-        `0 0 0 1px ${theme("colors.papaya.50")}`,
-        `0 1px 4px 0 ${rgba(theme("colors.papaya.50"), 0.16)}`,
-      ].join(),
-      "input-blur-papaya": `0 0 0 1px ${theme("colors.papaya.50")}`,
-      "checkbox-inset": [
-        "inset 0px 1px 1.5px rgba(0, 0, 0, 0.26)",
-        "inset 0px -1px 1.5px rgba(0, 0, 0, 0.1)",
-      ].join(),
       toggle: "0px 2px 6px rgba(0, 0, 0, 0.48)",
     }),
     extend: {
-      colors: {
-        carbon: {
-          // TODO: tailwind 2.x will automatically perform deep merges so it won't be
-          // necessary to spread the previous values anymore
-          ...theme.colors.carbon,
-          checkbox: "#b4b4b4",
-        },
-      },
-      borderRadius: {
-        checkbox: "0.1875rem",
-      },
       borderWidth: {
-        checkbox: "0.5px",
         6: "6px",
       },
       flex: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,4 @@
-const preset = require("@envoy/tailwind/tailwind.config.js");
+const preset = require("@envoy/tailwind");
 const hexRgb = require("hex-rgb");
 const resolveConfig = require("tailwindcss/resolveConfig");
 
@@ -10,7 +10,7 @@ function rgba(hex, alpha) {
 }
 
 module.exports = {
-  presets: [require("@envoy/tailwind")],
+  presets: [preset],
   theme: {
     // it's hard to extend boxShadow since it needs the complete string including color,
     // which is why the best place to define it is by overriding the entire boxShadow
@@ -74,94 +74,8 @@ module.exports = {
       },
       spacing: {
         2.5: "0.604rem",
-        2.75: "0.6666rem",
       },
     },
-    customForms: (theme) => ({
-      default: {
-        "input, textarea, select": {
-          color: theme("colors.carbon.70"),
-          borderColor: theme("colors.carbon.10"),
-          borderRadius: theme("borderRadius.md"),
-          "&:focus, &.focused:enabled:not(.error)": {
-            boxShadow: theme("boxShadow.input-gem"), // defined in TextField.module.css due to complex requirement with error state
-            borderColor: theme("colors.gem.50"),
-          },
-          "&.error": {
-            borderColor: theme("colors.papaya.50"),
-            boxShadow: theme("boxShadow.input-blur-papaya"),
-            "&:focus": {
-              boxShadow: theme("boxShadow.input-papaya"),
-            },
-          },
-        },
-        "input, textarea, checkbox, select": {
-          "&:disabled": {
-            color: theme("colors.carbon.60"),
-            "-webkit-text-fill-color": theme("colors.carbon.60"),
-            borderColor: theme("colors.carbon.10"),
-            backgroundColor: theme("colors.carbon.5"),
-          },
-        },
-        "input, textarea": {
-          paddingTop: theme("spacing.2"),
-          paddingRight: theme("spacing.2"),
-          paddingBottom: theme("spacing.2"),
-          paddingLeft: theme("spacing.2"),
-          "&::placeholder": {
-            color: theme("colors.carbon.20"),
-            lineHeight: "normal",
-          },
-        },
-        input: {
-          "&[type=search]": {
-            borderRadius: theme("borderRadius.full"),
-            paddingLeft: theme("spacing.8"),
-          },
-        },
-        checkbox: {
-          color: theme("colors.gem.50"),
-          borderRadius: theme("borderRadius.checkbox"),
-          borderColor: theme("colors.carbon.checkbox"),
-          boxShadow: theme("boxShadow.checkbox-inset"),
-          borderWidth: theme("borderWidth.checkbox"),
-          "&:checked": {
-            boxShadow: "none",
-          },
-          "&:focus": {
-            boxShadow: theme("boxShadow.checkbox-inset"),
-            borderColor: theme("colors.carbon.checkbox"),
-          },
-          "&:focus:checked": {
-            boxShadow: theme("boxShadow.outline"),
-            borderColor: theme("colors.gem.50"),
-          },
-          "&:indeterminate": {
-            background:
-              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='8' height='2' x='4' y='7' rx='1'/%3E%3C/svg%3E\");",
-            borderColor: "transparent",
-            backgroundColor: "currentColor",
-            backgroundSize: "100% 100%",
-            backgroundPosition: "center",
-            backgroundRepeat: "no-repeat",
-            boxShadow: "none",
-          },
-          "&:focus:indeterminate": {
-            boxShadow: theme("boxShadow.outline"),
-          },
-          // fix for :disabled overriding the :checked backgroundColor
-          "&:checked:disabled": {
-            backgroundColor: "currentColor",
-            borderColor: "currentColor",
-          },
-        },
-        select: {
-          iconColor: theme("colors.carbon.40"),
-          paddingTop: theme("spacing")["2.75"],
-          paddingBottom: theme("spacing")["2.75"],
-        },
-      },
-    }),
   },
   variants: {
     borderRadius: ({ after }) => after(["first", "last"]),
@@ -170,7 +84,6 @@ module.exports = {
     textColor: ({ after }) => after(["active"]),
   },
   plugins: [
-    require("@tailwindcss/custom-forms"),
     require("./src/plugins/fontMetrics")({
       emSquare: 1000,
       ascender: 756,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,12 +1168,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@envoy/tailwind@^1.0.4":
-  version "1.0.4"
-  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.4/8d6f60c1a5cd8976028526a96ac6ebff96d1ec6f55fd2c4ce3959f4247350954#c1a251e82ad39c31ddc587b43a7e37dc988aa227"
-  integrity sha512-tv7pF/5QHm6VoUWGsxeZF40StKAMKfF6U6OO/BbACSAP4oMdQPs6ElOkeH8uWSPjtKnRbvHC5hap8J+Vvis0Ng==
+"@envoy/tailwind@^1.0.5":
+  version "1.0.5"
+  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.5/3049829ebb8d4d68cff6fc5ca7fce6a058c2fd281bd7851b6cd77edba965c75b#9322d1117fc32c1818092db76384bc3cf8efc593"
+  integrity sha512-CVgUBnpicth6Y1RYoa6JjewoMHOWyTzLfBsO16neMhgfkjUQQA96B+vDd8dffue43qd74VL2Lv4WStO4XQc8dQ==
   dependencies:
     "@tailwindcss/custom-forms" "^0.2.1"
+    hex-rgb "^4.3.0"
 
 "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.3.0"
@@ -7980,10 +7981,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-hex-rgb@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.1.0.tgz#2d5d3a2943bd40e7dc9b0d5b98903d7d17035967"
-  integrity sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g==
+hex-rgb@^4.1.0, hex-rgb@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.3.0.tgz#af5e974e83bb2fefe44d55182b004ec818c07776"
+  integrity sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==
 
 highlight.js@^10.1.1, highlight.js@~10.4.0:
   version "10.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@envoy/tailwind@^1.0.5":
-  version "1.0.5"
-  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.5/3049829ebb8d4d68cff6fc5ca7fce6a058c2fd281bd7851b6cd77edba965c75b#9322d1117fc32c1818092db76384bc3cf8efc593"
-  integrity sha512-CVgUBnpicth6Y1RYoa6JjewoMHOWyTzLfBsO16neMhgfkjUQQA96B+vDd8dffue43qd74VL2Lv4WStO4XQc8dQ==
+"@envoy/tailwind@^1.0.6":
+  version "1.0.6"
+  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.6/0af242280f1717b4813b48c39743ed561fcb2be94cb60ef517f58a06568faed3#3fc1e7fecfa6bf8a32c6d86ba2d8f3c1c546957d"
+  integrity sha512-AeO1Ed6MAxqLV1PRPFCXop/6x7EXHS1ToHPGhZQifQnms137yLxYJEmZluRQYDFAvPxDrZI+U8CxDq4dT/vMrA==
   dependencies:
     "@tailwindcss/custom-forms" "^0.2.1"
     hex-rgb "^4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@envoy/tailwind@^1.0.2":
-  version "1.0.2"
-  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.2/e240c071b18505a8537358b7d8ca6fd3375cbf5ffd7d738336d9ee05c9ffcbf6#86f33626787d82c6d304743cb01f593762c3e9c7"
-  integrity sha512-t8gz6iVuqqNfMrw1p+wyhRdXc7hqi88iOqIhvxxk9WmORJKw1qEWu4YjHvwmNRIEFNsnhsmHhrHC2qZkA0kriw==
+"@envoy/tailwind@^1.0.3":
+  version "1.0.3"
+  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.3/a80449a88a1df55623b42dc8329b143553bc0a4c1d9ebcc52c3af70dcc97304f#83d871036e4ee20dce515b36035ce3e93b2d5dfa"
+  integrity sha512-RG6M8Jf5CApuOH8UmiBuU2wsOmN+eQk5NXHMMOy7o5C2g5nzwHifE/5ATntKhZmtzgamuSW/8anHU+BqCC1ovA==
+  dependencies:
+    "@tailwindcss/custom-forms" "^0.2.1"
 
 "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.3.0"
@@ -2483,6 +2485,15 @@
   dependencies:
     remark "^12.0.0"
     unist-util-find-all-after "^3.0.1"
+
+"@tailwindcss/custom-forms@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz#40e5ed1fff6d29d8ed1c508a0b2aaf8da96962e0"
+  integrity sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==
+  dependencies:
+    lodash "^4.17.11"
+    mini-svg-data-uri "^1.0.3"
+    traverse "^0.6.6"
 
 "@testing-library/dom@^7.2.2":
   version "7.2.2"
@@ -10475,7 +10486,7 @@ mini-css-extract-plugin@^0.9.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-mini-svg-data-uri@^1.1.3:
+mini-svg-data-uri@^1.0.3, mini-svg-data-uri@^1.1.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.2.3.tgz#e16baa92ad55ddaa1c2c135759129f41910bc39f"
   integrity sha512-zd6KCAyXgmq6FV1mR10oKXYtvmA9vRoB6xPSTUJTbFApCtkefDnYueVR1gkof3KcdLZo1Y8mjF2DFmQMIxsHNQ==
@@ -15431,6 +15442,11 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 tree-kill@^1.2.2:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@envoy/tailwind@^1.0.3":
-  version "1.0.3"
-  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.3/a80449a88a1df55623b42dc8329b143553bc0a4c1d9ebcc52c3af70dcc97304f#83d871036e4ee20dce515b36035ce3e93b2d5dfa"
-  integrity sha512-RG6M8Jf5CApuOH8UmiBuU2wsOmN+eQk5NXHMMOy7o5C2g5nzwHifE/5ATntKhZmtzgamuSW/8anHU+BqCC1ovA==
+"@envoy/tailwind@^1.0.4":
+  version "1.0.4"
+  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.4/8d6f60c1a5cd8976028526a96ac6ebff96d1ec6f55fd2c4ce3959f4247350954#c1a251e82ad39c31ddc587b43a7e37dc988aa227"
+  integrity sha512-tv7pF/5QHm6VoUWGsxeZF40StKAMKfF6U6OO/BbACSAP4oMdQPs6ElOkeH8uWSPjtKnRbvHC5hap8J+Vvis0Ng==
   dependencies:
     "@tailwindcss/custom-forms" "^0.2.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,15 +2484,6 @@
     remark "^12.0.0"
     unist-util-find-all-after "^3.0.1"
 
-"@tailwindcss/custom-forms@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz#40e5ed1fff6d29d8ed1c508a0b2aaf8da96962e0"
-  integrity sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==
-  dependencies:
-    lodash "^4.17.11"
-    mini-svg-data-uri "^1.0.3"
-    traverse "^0.6.6"
-
 "@testing-library/dom@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.2.2.tgz#30ab09cca132fe49b2ca61ccd9ed785c5f0a6fc5"
@@ -10484,7 +10475,7 @@ mini-css-extract-plugin@^0.9.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-mini-svg-data-uri@^1.0.3, mini-svg-data-uri@^1.1.3:
+mini-svg-data-uri@^1.1.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.2.3.tgz#e16baa92ad55ddaa1c2c135759129f41910bc39f"
   integrity sha512-zd6KCAyXgmq6FV1mR10oKXYtvmA9vRoB6xPSTUJTbFApCtkefDnYueVR1gkof3KcdLZo1Y8mjF2DFmQMIxsHNQ==
@@ -15440,11 +15431,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-traverse@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 tree-kill@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
`@envoy/tailwind` 1.0.6 bundles `@tailwindcss/custom-forms`. As such, we are able to remove our custom-forms dependency and config. This upgrade also requires Polarwind to be IE11-compatible.