### PR TITLE
Compensate for @envoy/tailwind's default padding for select when working with capsized font

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,7 @@
 ### Dependency upgrades
 
 - Upgraded to Tailwind 1.9.6
-- Upgraded to @envoy/tailwind 1.0.7
+- Upgraded to @envoy/tailwind 1.1.0
 
 ### Code quality
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
-    "@envoy/tailwind": "^1.0.7",
+    "@envoy/tailwind": "^1.1.0",
     "@percy/storybook": "^3.3.1",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-image": "^2.0.5",

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -1,6 +1,13 @@
 .Select {
   @apply leading-base-normal;
 
+  /**
+   * Override custom-form's select padding of 10px because that works well on an actual
+   * select element, but is too small when the trigger is replaced with a button as what
+   * we do with react-aria select
+   */
+  @apply py-2.75;
+
   span {
     @apply align-base;
   }

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect */
 /* eslint-disable react/prop-types */
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,7 @@ module.exports = {
       },
       spacing: {
         2.5: "0.604rem",
+        2.75: "0.6666rem",
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,10 +1229,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@envoy/tailwind@^1.0.7":
-  version "1.0.7"
-  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.0.7/c2dcb38a02f75978415fb3f8aafa337af7cd9337c3997e4f21d33b618c6bb77f#eb60993f2591c458bcdd4ca0e2c44722471de9c4"
-  integrity sha512-GbMlsgAB6jednXf4k/gFtpf438EM4tmoCcT2gWwqiE8QcY6kcPpR9HMQ9t1WaL0W1EooHC3nb7dEkqJIHwNJqA==
+"@envoy/tailwind@^1.1.0":
+  version "1.1.0"
+  resolved "https://npm.pkg.github.com/download/@envoy/tailwind/1.1.0/c97f35558f244a2314e00bdc1aebf119b0023ee637f756df03db66277e464d64#3df2478b19c48537ba69ca2ae256ae71d982d21c"
+  integrity sha512-t0alrYm/fqIJZpjoQ0mkEQR9HfgxfYQ3rHqTeK4X4N4wKHTlHhK4YfmYIz8xqL+NVWZzKFgAh18TNEs0/ym0fg==
   dependencies:
     "@tailwindcss/custom-forms" "^0.2.1"
     hex-rgb "^4.3.0"


### PR DESCRIPTION
@envoy/tailwind 1.1.0 introduced a smaller padding value for `form-select`. This PR overrides it with a bigger padding value that works best with our capheight-ed fonts.