### PR TITLE
optional prop inclusion for props with default values

### DIFF
--- a/src/components/AppProvider/AppProvider.d.ts
+++ b/src/components/AppProvider/AppProvider.d.ts
@@ -8,11 +8,11 @@ export declare const AppProvider: ({ children, embedded, origin, ownHost, theme,
     /**
      * Inner content of the application
      */
-    children?: React.ReactNode;
+    children: React.ReactNode;
     /**
      * Set whether running in embedded or standalone mode.
      */
-    embedded: boolean;
+    embedded?: boolean;
     /**
      * Envoy Dashboard origin.
      *
@@ -20,7 +20,7 @@ export declare const AppProvider: ({ children, embedded, origin, ownHost, theme,
      * determining if a link belongs to the host app, so that the appropriate message can be
      * sent up to perform the navigation.
      */
-    origin: string;
+    origin?: string;
     /**
      * Hostname of where the embedded app is hosted.
      *
@@ -30,9 +30,9 @@ export declare const AppProvider: ({ children, embedded, origin, ownHost, theme,
      * Otherwise, link handling will not be able to determine if it's an internal link and
      * set `target="_blank"` on the links.
      */
-    ownHost: string;
+    ownHost?: string;
     /**
      * Custom colors provided to select components
      */
-    theme?: Theme;
+    theme: Theme;
 }) => JSX.Element;

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -21,12 +21,12 @@ export const AppProvider = ({
   /**
    * Inner content of the application
    */
-  children?: React.ReactNode;
+  children: React.ReactNode;
 
   /**
    * Set whether running in embedded or standalone mode.
    */
-  embedded: boolean;
+  embedded?: boolean;
 
   /**
    * Envoy Dashboard origin.
@@ -35,7 +35,7 @@ export const AppProvider = ({
    * determining if a link belongs to the host app, so that the appropriate message can be
    * sent up to perform the navigation.
    */
-  origin: string;
+  origin?: string;
 
   /**
    * Hostname of where the embedded app is hosted.
@@ -46,12 +46,12 @@ export const AppProvider = ({
    * Otherwise, link handling will not be able to determine if it's an internal link and
    * set `target="_blank"` on the links.
    */
-  ownHost: string;
+  ownHost?: string;
 
   /**
    * Custom colors provided to select components
    */
-  theme?: Theme;
+  theme: Theme;
 }) => {
   return (
     <EmbeddedContext.Provider value={embedded}>


### PR DESCRIPTION
we had the optional props reversed. Haven't checked other components but noticed this issue when using AppProvider in another repo. This PR simply reverses them so that props with default values are optional, and those without are mandatory. It's possible these should all be optional perhaps whoever reviews this could provide clarity on that.